### PR TITLE
adds an install script for aescrypt Rust

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# installing aescrypt
+wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
+tar -xzf aescrypt-3.13.tgz
+cd aescrypt-3.13/src
+make && sudo make install
+cd ../.. && rm -rf aescrypt-3.13
+
+# installing Rust
+curl https://sh.rustup.rs -sSf | sh
+

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ else
     sudo cp target/release/abrute /usr/bin
 
     # Cleaning
+    cd ..
     rm master.zip
     rm -r abrute-master/
 fi

--- a/install.sh
+++ b/install.sh
@@ -11,24 +11,40 @@ then
 else
     # Rust is not installed
     # Ask for user consent before proceeding with installation
-    read -p "Rust is not installed. Do you want to install Rust now ? (necessary for Abrute) [y/n] " answer
+    read -p "Rust is not installed. Do you want to install Rust now ? (necessary for Abrute) [y/n] " Rust_answer
 
-    if [ $answer == y ];
+    if [ $Rust_answer == y ];
     then
         # User agreed, proceed with installation
-        curl https://sh.rustup.rs -sSf | sh
+        # curl https://sh.rustup.rs -sSf | sh
+        echo "là on installe Rust"
     else
         # User refused, abort installation
         exit 1
     fi
 fi
 
+# Checking if Aescrypt is installed
+if [ -f /usr/bin/aescrypt ] && [ -f /usr/bin/aescrypt_keygen ];
+then
+    # Aescrypt is already installed
+    echo "Aescrypt already installed"
+else
+    read -p "Aescrypt is not installed. Do you want to install Aescrypt now ? (necessary for Abrute) [y/n] " AES_answer
 
-# installing aescrypt
-wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
-tar -xzf aescrypt-3.13.tgz
-cd aescrypt-3.13/src
-make && sudo make install
-cd ../.. && rm -rf aescrypt-3.13
+    if [ $AES_answer == y ];
+    then
+        User agreed, proceed with installation
+        wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
+        tar -xzf aescrypt-3.13.tgz
+        cd aescrypt-3.13/src
+        make && sudo make install
+        cd ../.. && rm -rf aescrypt-3.13 && rm aescrypt-3.13.tgz
+    else
+        # User refused, abort installation
+        exit 1
+    fi
+fi
+
 
 

--- a/install.sh
+++ b/install.sh
@@ -46,5 +46,8 @@ else
     fi
 fi
 
+cargo build --release
+sudo cp target/release/abrute /usr/bin
 
+echo "Thank you for installing Abrute. Enjoy !"
 

--- a/install.sh
+++ b/install.sh
@@ -29,20 +29,14 @@ then
     # Aescrypt is already installed
     echo "Aescrypt already installed"
 else
-    read -p "Aescrypt is not installed. Do you want to install Aescrypt now ? (necessary for Abrute) [y/n] " AES_answer
-
-    if [ $AES_answer == y ];
-    then
-        User agreed, proceed with installation
-        wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
-        tar -xzf aescrypt-3.13.tgz
-        cd aescrypt-3.13/src
-        make && sudo make install
-        cd ../.. && rm -rf aescrypt-3.13 && rm aescrypt-3.13.tgz
-    else
-        # User refused, abort installation
-        exit 1
-    fi
+    echo "Installing Aescrypt"
+    User agreed, proceed with installation
+    wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
+    tar -xzf aescrypt-3.13.tgz
+    cd aescrypt-3.13/src
+    make && sudo make install
+    cd ../.. && rm -rf aescrypt-3.13 && rm aescrypt-3.13.tgz
+    echo "Aescrypt installed"
 fi
 
 cargo build --release

--- a/install.sh
+++ b/install.sh
@@ -39,8 +39,24 @@ else
     echo "Aescrypt installed"
 fi
 
-cargo build --release
-sudo cp target/release/abrute /usr/bin
+# Checking for the existence of source files
+if [ -d src ] && [ -d .git ];
+then
+    # The source files are already there. We can build and install Abrute.
+    cargo build --release
+    sudo cp target/release/abrute /usr/bin
+else
+    # Downloading the source files
+    wget https://github.com/danielpclark/abrute/archive/master.zip
+    unzip master.zip
+    cd abrute-master
+    cargo build --release
+    sudo cp target/release/abrute /usr/bin
+
+    # Cleaning
+    rm master.zip
+    rm -r abrute-master/
+fi
 
 echo "Thank you for installing Abrute. Enjoy !"
 

--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ then
     # Aescrypt is already installed
     echo "Aescrypt already installed"
 else
+    # Aescrypt is not installed, proceed with installation
     echo "Installing Aescrypt"
-    User agreed, proceed with installation
     wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
     tar -xzf aescrypt-3.13.tgz
     cd aescrypt-3.13/src
@@ -50,6 +50,8 @@ else
     wget https://github.com/danielpclark/abrute/archive/master.zip
     unzip master.zip
     cd abrute-master
+    
+    # Building and installing
     cargo build --release
     sudo cp target/release/abrute /usr/bin
 

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,7 @@ else
     if [ $Rust_answer == y ];
     then
         # User agreed, proceed with installation
-        # curl https://sh.rustup.rs -sSf | sh
-        echo "là on installe Rust"
+        curl https://sh.rustup.rs -sSf | sh
     else
         # User refused, abort installation
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+rust_install_status=`rustc --version`
+rustc_prefix="rustc"
+
+# Checking if Rust is installed
+if [[ $rust_install_status == $rustc_prefix* ]];
+then
+    # Rust is installed
+    echo "Rust already installed"
+else
+    # Rust is not installed
+    # Ask for user consent before proceeding with installation
+    read -p "Rust is not installed. Do you want to install Rust now ? (necessary for Abrute) [y/n] " answer
+
+    if [ $answer == y ];
+    then
+        # User agreed, proceed with installation
+        curl https://sh.rustup.rs -sSf | sh
+    else
+        # User refused, abort installation
+        exit 1
+    fi
+fi
+
+
 # installing aescrypt
 wget https://www.aescrypt.com/download/v3/linux/aescrypt-3.13.tgz
 tar -xzf aescrypt-3.13.tgz
@@ -7,6 +31,4 @@ cd aescrypt-3.13/src
 make && sudo make install
 cd ../.. && rm -rf aescrypt-3.13
 
-# installing Rust
-curl https://sh.rustup.rs -sSf | sh
 


### PR DESCRIPTION
Adds an `install.sh` shell script which retrieves aescrypt and Rust.
If the script is hosted at `www.myadress.com/path`, then it can be executed by firing the following command :

`curl www.myadress.com/path | sh`

Should the script also execute 
`cargo build --release`
`sudo cp target/release/abrute /usr/bin/` ?